### PR TITLE
Ignore commit hash in version name, so there are no false "update available"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 android {
 	compileSdkVersion 23
-	buildToolsVersion '23.0.3'
+	buildToolsVersion '25.0.2'
 
     defaultConfig {
         versionCode 21

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ android {
 	buildToolsVersion '25.0.2'
 
     defaultConfig {
-        versionCode 21
-        versionName '2.1'
+        versionCode 22
+        versionName '2.2'
     }
 
 	sourceSets {

--- a/src/com/pyler/aquamail/updater/Checker.java
+++ b/src/com/pyler/aquamail/updater/Checker.java
@@ -51,8 +51,7 @@ public class Checker extends BroadcastReceiver {
                             if (result != null) {
                                 newVersionName = helper
                                         .getLatestVersion(result);
-                                if (!newVersionName
-                                        .equals(installedVersionName)) {
+                                if (helper.isUpdate(newVersionName, installedVersionName)) {
                                     Intent openIntent = new Intent(context,
                                             Updater.class);
                                     PendingIntent pendingIntent = PendingIntent

--- a/src/com/pyler/aquamail/updater/Helper.java
+++ b/src/com/pyler/aquamail/updater/Helper.java
@@ -175,6 +175,19 @@ public class Helper {
     }
 
 	private String cleanVersionNameForCompare(String version) {
+		version = removeVersionCommitHash(version);
+
+		for (String suffix : new String[] {SUFFIX_STABLE, SUFFIX_DEV}) {
+			if (version.endsWith(suffix)) {
+				version = version.substring(0, version.length() - suffix.length());
+				break;
+			}
+		}
+
+		return version;
+	}
+
+	private String removeVersionCommitHash(String version) {
 		// Remove commit hash, should be 12 characters
 		for (int i = version.length() - 1; i >= 0; --i) {
 			final char ch = version.charAt(i);
@@ -187,13 +200,6 @@ public class Helper {
 				// Valid
 			} else {
 				// Not valid
-				break;
-			}
-		}
-
-		for (String suffix : new String[] {SUFFIX_STABLE, SUFFIX_DEV}) {
-			if (version.endsWith(suffix)) {
-				version = version.substring(0, version.length() - suffix.length());
 				break;
 			}
 		}

--- a/src/com/pyler/aquamail/updater/Updater.java
+++ b/src/com/pyler/aquamail/updater/Updater.java
@@ -182,7 +182,7 @@ public class Updater extends Activity {
                                     .setText(getString(R.string.latest_version,
                                             latestVersionName));
                             checkOtherBuilds();
-                            if (!latestVersionName.equals(installedVersionName)) {
+                            if (helper.isUpdate(latestVersionName, installedVersionName)) {
                                 downloadButton.setVisibility(View.VISIBLE);
                                 if (getChangelog() == 0) {
                                     showChangelog();
@@ -307,7 +307,7 @@ public class Updater extends Activity {
                         if (result != null) {
                             String latestBuildVersionName = helper.getLatestVersion(result);
                             String latestLoadedVersionName = prefs.getString(versionId, "0");
-                            if (!latestBuildVersionName.equals(latestLoadedVersionName)) {
+                            if (helper.isUpdate(latestBuildVersionName, latestLoadedVersionName)) {
                                 prefs.edit().putString(versionId, latestBuildVersionName).apply();
                                 showNewOtherBuildDialog(latestVersionName);
                             }


### PR DESCRIPTION
Handles cases like:

Installed version: 1.7.2-132
Latest version: 1.7.2-132-stable-44a9e5fb96c0

Before: "update is available"
Now: there is no update

Also handles:

Installed: 1.8.0-133-dev
Latest: 1.8.0-133-dev-037a77a0aa54


